### PR TITLE
index xml source from harvest object or xml location url

### DIFF
--- a/.github/workflows/build_parent_on_pull_requests.yml
+++ b/.github/workflows/build_parent_on_pull_requests.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow that is manually triggered
+
+name: Build ckan on pull request
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+  pull_request:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  Dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_DISPATCH_ACCESS_TOKEN }}
+        repository: cioos-siooc/ckan
+        event-type: submodule-pull-request
+        client-payload: '{"submodule": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "head_ref":"${{ github.event.pull_request.head.ref }}", "head_sha":"${{ github.event.pull_request.head.sha }}", "base_ref":"${{ github.event.pull_request.base.ref }}", "base_sha":"${{ github.event.pull_request.base.sha }}", "prn":"${{ github.event.pull_request.number}}"}'


### PR DESCRIPTION
index xml source when available. first tries to index harvested object as this is already in the database. if harvest object is not xml (came from another ckan and thus is json) or just not available then it tries to read the xml file from the xml location url field.

indexed xml is stored in extras_harvest_document_content which only exists in the solr index and is also included in the 'All Text' search. To see the contents of this field you must query it with the 'fl' attribute set.

eg. https://localhost/api/3/action/package_search?fl=extras_harvest_document_content