### PR TITLE
change roles scraped from cited-responsible-party

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -366,7 +366,7 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IPackageController
 
     def _cited_responsible_party_to_responsible_organizations(self, parties):
-        resp_org_roles = toolkit.config.get('ckan.responsible_organization_roles', ['owner', 'originator', 'custodian', 'author', 'principalInvestigator'])
+        resp_org_roles = json.loads(toolkit.config.get('ckan.responsible_organization_roles', '["owner", "originator", "custodian", "author", "principalInvestigator"]'))
         resp_orgs = [x.get('organisation-name', '').strip() for x in json.loads(parties) if x.get('role') in resp_org_roles]
         resp_orgs = list(dict.fromkeys(resp_orgs))  # remove duplicates
         return resp_orgs

--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -366,7 +366,11 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IPackageController
 
     def _cited_responsible_party_to_responsible_organizations(self, parties):
-        return [x.get('organisation-name', '').strip() for x in json.loads(parties) if x.get('role') in ['originator']]
+        resp_org_roles = toolkit.config.get('ckan.responsible_organization_roles', ['owner', 'originator', 'custodian', 'author', 'principalInvestigator'])
+        resp_orgs = [x.get('organisation-name', '').strip() for x in json.loads(parties) if x.get('role') in resp_org_roles]
+        resp_orgs = list(dict.fromkeys(resp_orgs))  # remove duplicates
+        return resp_orgs
+
     # modfiey tags, keywords, and eov fields so that they properly index
     def before_index(self, data_dict):
         data_type = data_dict.get('type')


### PR DESCRIPTION
fix cioos-siooc/ckan#76 (maybe)

add a `ckan.responsible_organization_roles` config setting to set which roles are pulled from 'cited-responsible-party' to populate 'responsible_organizations' during indexing. Defaults to ["owner", "originator", "custodian", "author", "principalInvestigator"]

example config entry
```
ckan.responsible_organization_role = ["owner", "originator", "custodian", "author", "principalInvestigator"]
```