### PR TITLE
add datacite xml output per dataset

### DIFF
--- a/ckanext/cioos_theme/helpers.py
+++ b/ckanext/cioos_theme/helpers.py
@@ -61,6 +61,27 @@ get_action = logic.get_action
 #     return default
 
 
+def generate_doi_suffix():
+    import random
+    chars = ['a','b','c','d','e','f','g','h','j','k','m','n','p','q','r','s',
+             't','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9']
+    str1 = ''.join(random.SystemRandom().choice(chars) for _ in range(4))
+    str2 = ''.join(random.SystemRandom().choice(chars) for _ in range(4))
+    return str1 + '-' + str2
+
+def get_doi_authority_url():
+    return toolkit.config.get('ckan.cioos.doi_authority_url', 'https://doi.org/')
+
+def get_doi_prefix():
+    return toolkit.config.get('ckan.cioos.doi_prefix')
+
+def get_datacite_org():
+    return toolkit.config.get('ckan.cioos.datacite_org')
+
+def get_datacite_test_mode():
+    return toolkit.config.get('ckan.cioos.datacite_test_mode', 'True')
+
+
 def _merge_lists(key, list1, list2):
     merged = {}
     for item in list1 + list2:

--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -274,7 +274,6 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
             'cioos_get_locale_url': self.get_locale_url,
             'cioos_schema_field_map': cioos_helpers.cioos_schema_field_map,
             'cioos_get_additional_css_path': self.get_additional_css_path,
-            'cioos_generate_doi_suffix': cioos_helpers.generate_doi_suffix,
             'cioos_get_doi_authority_url': cioos_helpers.get_doi_authority_url,
             'cioos_get_doi_prefix': cioos_helpers.get_doi_prefix,
             'cioos_get_datacite_org': cioos_helpers.get_datacite_org,

--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -168,6 +168,9 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     def before_map(self, route_map):
         with routes.mapper.SubMapper(route_map, controller='ckanext.cioos_theme.plugin:CIOOSController') as m:
             m.connect('schemamap', '/schemamap', action='schemamap')
+            m.connect('datacite_xml', '/dataset/{id}.{format}',
+                      action='datacite_xml',
+                      requirements={'format': 'dcxml'})
         return route_map
 
     def after_map(self, route_map):
@@ -270,7 +273,12 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
             'cioos_get_eovs': cioos_helpers.cioos_get_eovs,
             'cioos_get_locale_url': self.get_locale_url,
             'cioos_schema_field_map': cioos_helpers.cioos_schema_field_map,
-            'cioos_get_additional_css_path': self.get_additional_css_path
+            'cioos_get_additional_css_path': self.get_additional_css_path,
+            'cioos_generate_doi_suffix': cioos_helpers.generate_doi_suffix,
+            'cioos_get_doi_authority_url': cioos_helpers.get_doi_authority_url,
+            'cioos_get_doi_prefix': cioos_helpers.get_doi_prefix,
+            'cioos_get_datacite_org': cioos_helpers.get_datacite_org,
+            'cioos_get_datacite_test_mode': cioos_helpers.get_datacite_test_mode
         }
 
     def get_validators(self):
@@ -549,8 +557,8 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
                         result['organization'] = organization
                 else:
                     log.warn('No org details for owner_org %s', result.get('org_descriptionid'))
-            else:
-                log.warn('No owner_org for dataset %s: %s: %s', result.get('id'), result.get('name'), result.get('title'))
+            # else:
+            #    log.warn('No owner_org for dataset %s: %s: %s', result.get('id'), result.get('name'), result.get('title'))
 
         return search_results
 
@@ -614,3 +622,7 @@ class CIOOSController(base.BaseController):
 
     def schemamap(self):
         return base.render('schemamap.html')
+
+    def datacite_xml(self, id):
+        pkg = toolkit.get_action('package_show')(data_dict={'id': id})
+        return base.render('package/datacite.html', extra_vars={'pkg_dict':pkg})

--- a/ckanext/cioos_theme/templates/package/datacite.html
+++ b/ckanext/cioos_theme/templates/package/datacite.html
@@ -1,0 +1,150 @@
+{% extends "page.html" %}
+
+{% set pkg = c.pkg_dict or pkg_dict %}
+{% block subtitle %}{{ _('Schema Map') }}{% endblock %}
+
+{% block breadcrumb_content %}
+<li class="active">{% link_for _('Schema Map'), controller='ckanext.cioos_theme.plugin:CIOOSController', action='schemamap' %}</li>
+{% endblock %}
+
+{% block primary %}
+<section class="module">
+  <div class="module-content">
+    <div class="col-sm-12">
+      <table>
+        {% set doi = h.cioos_load_json(pkg['unique-resource-identifier-full']) %}
+        {% if doi %}
+        {% set doi = doi['code'] %}
+        {% endif %}
+        {% if h.is_url(doi) %}
+        {% set doi = doi.replace(h.cioos_get_doi_authority_url(), '') %}
+        {% endif %}
+        <tr>
+          <th>DOI:</th>
+          <td>{{doi or 'Will be set later, during upload'}}</td>
+        </tr>
+        <tr>
+          <th>URL:</th>
+          <td>{{h.url_for(controller='package', action='read', id=pkg['name'], _external=True)}}</td>
+        </tr>
+        {% if h.cioos_get_datacite_test_mode() == 'True' %}
+        <tr>
+          <th>DateCite:</th>
+          <td><a href="https://doi.test.datacite.org/repositories/{{ h.cioos_get_datacite_org() or '*NOT SET*'}}/dois/upload" target="_blank">Test Upload Link</a></td>
+        </tr>
+        {% else %}
+        <tr>
+          <th>DateCite:</th>
+          <td><a href="https://doi.datacite.org/repositories/{{ h.cioos_get_datacite_org() or '*NOT SET*'}}/dois/upload" target="_blank">Live Upload Link</a></td>
+        </tr>
+        {% endif %}
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="module">
+  <div class="module-content">
+    <div class="col-sm-10">
+      <h3>XML</h3>
+    </div>
+    <div class="col-sm-2">
+      <button type="button" style="margin-top: 20px; margin-bottom: 10px; float: right;" onclick="saveXML(name='{{pkg['name']}}')">Save</button>
+    </div>
+
+    <textarea id='xml' style="width: 100%; height: 600px;">
+  <?xml version="1.0" encoding="UTF-8"?>
+  <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+    {% if doi -%}
+    <identifier identifierType="DOI">10.5072/example-full</identifier>
+    {%- endif -%}
+    <creators>
+      {%- for party in h.cioos_load_json(pkg['cited-responsible-party']) -%}
+        {%- if party['individual-name'] -%}
+        <creator>
+          {% set names = party['individual-name'].split(' ') %}
+          <creatorName nameType="Personal">{{ names[-1], ' '.join(names[:-1]) }}</creatorName>
+          <givenName>{{ ' '.join(names[:-1]) }}</givenName>
+          <familyName>{{ names[-1] }}</familyName>
+        </creator>
+        {%- endif -%}
+      {%- endfor -%}
+    </creators>
+    <titles>
+      <title xml:lang="en">{{ pkg['title_translated']['en'] }}</title>
+      <title xml:lang="fr">{{ pkg['title_translated']['fr'] }}</title>
+    </titles>
+    {%- for party in h.cioos_load_json(pkg['cited-responsible-party']) -%}
+      {% if party['role'] == 'publisher' %}
+    <publisher>party['organization-name']</publisher>
+      {% endif %}
+    {%- endfor -%}
+
+    {%- for date in h.cioos_load_json(pkg['dataset-reference-date']) -%}
+      {% if date['type'] == 'publication' %}
+    <publicationYear>{{ date['value'] }}</publicationYear>
+      {% endif %}
+    {%- endfor -%}
+    <subjects>
+      {%- for kw in pkg['keywords']['en'] %}
+      <subject xml:lang="en">{{ kw }}</subject>
+      {%- endfor %}
+      {%- for kw in pkg['keywords']['fr'] %}
+      <subject xml:lang="fr">{{ kw }}</subject>
+      {%- endfor %}
+    </subjects>
+    <language>{{ pkg['metadata-language'] }}</language>
+    <resourceType resourceTypeGeneral="{{ pkg['resource-type'].title() }}">{{ pkg['resource-type'].title() }}</resourceType>
+    <version>{{pkg['version'] or '1.0' }}</version>
+    <descriptions>
+      <description xml:lang="en" descriptionType="Abstract">
+        {{ pkg['notes_translated']['en'] }}
+      </description>
+      <description xml:lang="fr" descriptionType="Abstract">
+        {{ pkg['notes_translated']['fr'] }}
+      </description>
+    </descriptions>
+
+    <geoLocations>
+      <geoLocation>
+        <geoLocationBox>
+          <westBoundLongitude>{{pkg['bbox-west-long']}}</westBoundLongitude>
+          <eastBoundLongitude>{{pkg['bbox-east-long']}}</eastBoundLongitude>
+          <southBoundLatitude>{{pkg['bbox-south-lat']}}</southBoundLatitude>
+          <northBoundLatitude>{{pkg['bbox-north-lat']}}</northBoundLatitude>
+        </geoLocationBox>
+        {% set spatial = h.cioos_load_json(pkg['spatial']) %}
+        {%- if  spatial and spatial['type'] == 'Polygon' %}
+        <geoLocationPolygon>
+          {%- for coord in spatial['coordinates'][0] %}
+          <polygonPoint>
+            <pointLatitude>{{coord[1]}}</pointLatitude>
+            <pointLongitude>{{coord[0]}}</pointLongitude>
+          </polygonPoint>
+          {%- endfor %}
+        </geoLocationPolygon>
+        {%- endif %}
+      </geoLocation>
+    </geoLocations>
+
+  </resource>
+  </textarea>
+  </div>
+</section>
+
+<script src="{{h.url_for_static('/js/FileSaver.min.js')}}" type="text/javascript"></script>
+
+<script>
+  function saveXML() {
+
+    let el = document.querySelectorAll("#xml");
+    var textProperty = 'textContent' in document ? 'textContent' : 'innerText';
+    let blob = new Blob([el[0][textProperty]], {
+      type: "text/xml;charset=utf-8"
+    });
+    saveAs(blob, "metadata.xml");
+  }
+</script>
+{% endblock %}
+
+{% block secondary %}{% endblock %}

--- a/ckanext/cioos_theme/templates/package/read.html
+++ b/ckanext/cioos_theme/templates/package/read.html
@@ -39,7 +39,8 @@
     {% endblock %}
 
     <!-- <a href="{{ h.url_for('package_export', package_id=pkg.name, file_format='cioos', extension='xml')}}" class="btn"><i class="fa fa-icon fa-file-text"></i>{{ _(' CIOOS ISO 19139 ')}}</a> -->
-    <a href="{{ h.url_for(controller='package', action='read', id=pkg.id) }}" class="btn"><i class="fa fa-icon fa-link"></i>{{ _('Show Permalink')}}</a>
+    <a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}.dcxml" class="btn"><i class="fa fa-icon fa-link"></i>{{ _(' DataCite XML')}}</a>
+    <a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}" class="btn"><i class="fa fa-icon fa-link"></i>{{ _(' Show Permalink ')}}</a>
 
   {% endblock %}
 

--- a/ckanext/cioos_theme/templates/package/read.html
+++ b/ckanext/cioos_theme/templates/package/read.html
@@ -39,7 +39,9 @@
     {% endblock %}
 
     <!-- <a href="{{ h.url_for('package_export', package_id=pkg.name, file_format='cioos', extension='xml')}}" class="btn"><i class="fa fa-icon fa-file-text"></i>{{ _(' CIOOS ISO 19139 ')}}</a> -->
+    {% if c.userobj %}
     <a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}.dcxml" class="btn"><i class="fa fa-icon fa-link"></i>{{ _(' DataCite XML')}}</a>
+    {% endif %}
     <a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}" class="btn"><i class="fa fa-icon fa-link"></i>{{ _(' Show Permalink ')}}</a>
 
   {% endblock %}


### PR DESCRIPTION
Add a datacite xml link to dataset pages. Link is only accessable by authenticated users (logged in)

example config file settings:
```
ckan.cioos.doi_authority_url = https://doi.org/
ckan.cioos.datacite_org = hakai.dfukgl
ckan.cioos.datacite_test_mode = True
```