### PR TITLE
Updating for python 3 - string constant change

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -126,7 +126,7 @@ def url_validator_with_port(key, data, errors, context):
     try:
         pieces = urlparse(url)
         if all([pieces.scheme, pieces.netloc]) and \
-           set(pieces.netloc) <= set(string.letters + string.digits + '-.:') and \
+           set(pieces.netloc) <= set(string.ascii_letters + string.digits + '-.:') and \
            pieces.scheme in ['http', 'https']:
             return
     except ValueError:


### PR DESCRIPTION
`string.letters` replaced with `string.ascii_letters`

Fixes an issue with updating config in CKAN, causes an attribute error due to change in the name of the constant