### PR TITLE
populate responsible organisation

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -433,9 +433,10 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
                 resp_orgs = [force_responsible_organization]
         else:
             resp_org_roles = cioos_helpers.load_json(toolkit.config.get('ckan.responsible_organization_roles', '["owner", "originator", "custodian", "author", "principalInvestigator"]'))
-            resp_orgs = [x.get('organisation-name', '').strip() for x in cioos_helpers.load_json(parties) if x.get('role') in resp_org_roles]
+            resp_orgs = [x.get('organisation-name', '').strip() for x in cioos_helpers.load_json(parties) if not set(cioos_helpers.load_json(x.get('role'))).isdisjoint(resp_org_roles)]
             resp_orgs = list(dict.fromkeys(resp_orgs))  # remove duplicates
             resp_orgs = list(filter(None, resp_orgs))  # remove empty elements (in a python 2 and 3 friendly way)
+
         return resp_orgs
 
     def _get_extra_value(self, key, package_dict):
@@ -536,7 +537,7 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
         dict_out = {}
 
         for d in dict_list:
-            group_value = d['individual-name'] or d['organisation-name']
+            group_value = d.get('individual-name') or d.get('organisation-name')
             if not dict_out.get(group_value):
                 dict_out[group_value] = defaultdict(list)
             for key, value in d.items():
@@ -545,7 +546,7 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
                 else:
                     dict_out[group_value][key].append(value)
         for d in dict_list:
-            group_value = d['individual-name'] or d['organisation-name']
+            group_value = d.get('individual-name') or d.get('organisation-name')
             dict_out[group_value] = dict(dict_out[group_value])
 
         for k1, v1 in dict_out.items():


### PR DESCRIPTION
fix https://github.com/cioos-siooc/ckan/issues/140

role is an array now to support grouping of parties. repressible organisation is populated by filtering cited-responsible-partie on role.