### PR TITLE
Implement deduplication for oversized responsible-party lists to prevent Solr indexing errors

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -853,6 +853,31 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
 
             if data_dict.get('projects'):
                 data_dict['projects'] = cioos_helpers.load_json(data_dict.get('projects'))
+
+            # Solr StrField has a hard 32766-byte limit per term. A handful of
+            # records have responsible-party lists with the same individual
+            # repeated across many roles, which can push the JSON blob past
+            # that limit and break indexing. Only intervene when the limit is
+            # actually exceeded so other records are byte-for-byte unchanged.
+            SOLR_STR_FIELD_LIMIT = 32000
+            for field in ('metadata-point-of-contact', 'cited-responsible-party'):
+                value = data_dict.get(field)
+                if not value or not isinstance(value, str):
+                    continue
+                if len(value.encode('utf-8')) <= SOLR_STR_FIELD_LIMIT:
+                    continue
+                try:
+                    grouped = self.group_by_ind_or_org(cioos_helpers.load_json(value))
+                    deduped = json.dumps(grouped)
+                except Exception as err:
+                    log.error('Failed to dedupe oversized %s for %s: %s', field, data_dict.get('id', 'NO ID'), err)
+                    data_dict.pop(field, None)
+                    continue
+                if len(deduped.encode('utf-8')) <= SOLR_STR_FIELD_LIMIT:
+                    data_dict[field] = deduped
+                else:
+                    log.warning('Dropping %s from Solr doc for %s: %d bytes after dedupe exceeds limit', field, data_dict.get('id', 'NO ID'), len(deduped.encode('utf-8')))
+                    data_dict.pop(field, None)
         except Exception as e:
             log.exception(e)
             raise e

--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -862,12 +862,22 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
             SOLR_STR_FIELD_LIMIT = 32000
             for field in ('metadata-point-of-contact', 'cited-responsible-party'):
                 value = data_dict.get(field)
-                if not value or not isinstance(value, str):
+                if not value:
                     continue
-                if len(value.encode('utf-8')) <= SOLR_STR_FIELD_LIMIT:
+                if isinstance(value, str):
+                    serialized = value
+                    parsed = cioos_helpers.load_json(value)
+                else:
+                    parsed = value
+                    try:
+                        serialized = json.dumps(value)
+                    except Exception as err:
+                        log.error('Failed to serialize %s for size check (%s): %s', field, data_dict.get('id', 'NO ID'), err)
+                        continue
+                if len(serialized.encode('utf-8')) <= SOLR_STR_FIELD_LIMIT:
                     continue
                 try:
-                    grouped = self.group_by_ind_or_org(cioos_helpers.load_json(value))
+                    grouped = self.group_by_ind_or_org(parsed)
                     deduped = json.dumps(grouped)
                 except Exception as err:
                     log.error('Failed to dedupe oversized %s for %s: %s', field, data_dict.get('id', 'NO ID'), err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyld
+pyld==2.0.4  # newer versions require Python 3.10+ (PEP 604 syntax)
 jsonpickle


### PR DESCRIPTION
This pull request addresses an issue with Solr indexing failures caused by oversized JSON blobs in responsible-party fields. The main change introduces logic to ensure these fields do not exceed Solr's strict string field size limit, using deduplication as a fallback before dropping problematic data.

**Solr field size handling for responsible-party fields:**

* Added logic in `before_index` (in `ckanext/cioos_theme/plugin.py`) to check if the `metadata-point-of-contact` and `cited-responsible-party` fields exceed Solr's 32,000-byte limit, deduplicate their contents if necessary, and drop the field if it still exceeds the limit after deduplication.